### PR TITLE
Fix/wasm bindgen cli

### DIFF
--- a/scripts/build-wasm.ts
+++ b/scripts/build-wasm.ts
@@ -105,7 +105,7 @@ async function runWasmBindgen(args: {
 }) {
     // make sure wasm-bindgen cli is installed
     const wasmBindgenInstallProcess = new Deno.Command("cargo", {
-        args: ["install", "wasm-bindgen-cli"],
+        args: ["install", "wasm-bindgen-cli", "--version", "0.2.112"],
     }).spawn();
     const installRes = await wasmBindgenInstallProcess.status;
     if (!installRes.success) {


### PR DESCRIPTION
We have to pin the cli version, as otherwise the build fails if incompatible with the pinned versions of runtime bindgen etc. in Cargo.lock